### PR TITLE
Add render function prop to MediaQuery component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,13 @@ export function useMediaQuery(query) {
   return matches;
 }
 
-export function MediaQuery({ query, children }) {
+export function MediaQuery({ query, render, children }) {
   const matches = useMediaQuery(query);
-  return matches ? children : null;
+
+  if (matches && render) {
+    return render();
+  } else if (matches) {
+    return children;
+  }
+  return null;
 }


### PR DESCRIPTION
Adds a `render` property to the MediaQuery component which accepts a function that returns React elements and is only called if the media query given to the MediaQuery component matches. Can be used instead of the `children` property as an optimization in the case that you have a ton of elements under MediaQuery that don't need to be created if they aren't going to be rendered.

Fixes #2. Needs to be tested and evaluated more to determine if it's even necessary with the useMediaQuery hook.