### PR TITLE
Fix listen cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,13 +22,19 @@ export function useMediaQuery(query) {
         mq.removeListener(cb);
       };
 
-      if (lastQuery.current === undefined) {
+      if (
+        lastQuery.current === undefined ||
+        lastQuery.current === null ||
+        lastQuery.current === ""
+      ) {
         setMatches(mq.matches);
       }
     }
 
     lastQuery.current = query;
   }
+
+  React.useEffect(() => cancel.current, [cancel.current]);
 
   return matches;
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,47 +1,55 @@
+import { setMatches } from "./matchMedia.mock.js";
 import React from "react";
-import "react-testing-library/cleanup-after-each";
-import { render } from "react-testing-library";
-import { MediaQuery, useMediaQuery } from "../src/";
+import { render, act, cleanup } from "react-testing-library";
+import { MediaQuery, useMediaQuery } from "./index.js";
 
 const MATCH = "MATCH";
 const NO_MATCH = "NO_MATCH";
 const QUERY = "dummy query";
 
-function buildMatchMedia(matches) {
-  return () => ({
-    matches,
-    addListener: () => undefined,
-    removeListener: () => undefined
-  });
-}
-
 function HookComp() {
   return useMediaQuery(QUERY) ? MATCH : NO_MATCH;
 }
 
+afterEach(cleanup);
+
 describe("useMediaQuery", () => {
   test("returns true when match", () => {
-    window.matchMedia = buildMatchMedia(true);
+    setMatches(true);
     const { container } = render(<HookComp />);
     expect(container.textContent).toBe(MATCH);
   });
 
   test("returns false when doesn't match", () => {
-    window.matchMedia = buildMatchMedia(false);
+    setMatches(false);
     const { container } = render(<HookComp />);
     expect(container.textContent).toBe(NO_MATCH);
+  });
+
+  test("listens to changes", () => {
+    setMatches(true);
+    const { container } = render(<HookComp />);
+    expect(container.textContent).toBe(MATCH);
+    act(() => {
+      setMatches(false);
+    });
+    expect(container.textContent).toBe(NO_MATCH);
+    act(() => {
+      setMatches(true);
+    });
+    expect(container.textContent).toBe(MATCH);
   });
 });
 
 describe("MediaQuery", () => {
   test("renders when match", () => {
-    window.matchMedia = buildMatchMedia(true);
+    setMatches(true);
     const { container } = render(<MediaQuery query={QUERY} children={MATCH} />);
     expect(container.textContent).toBe(MATCH);
   });
 
   test("doesn't render when doesn't match", () => {
-    window.matchMedia = buildMatchMedia(false);
+    setMatches(false);
     const { container } = render(
       <MediaQuery query={QUERY} children={NO_MATCH} />
     );

--- a/src/matchMedia.mock.js
+++ b/src/matchMedia.mock.js
@@ -1,0 +1,21 @@
+export let _matches = false;
+let listeners = [];
+
+window.matchMedia = jest.fn(() => {
+  return {
+    get matches() {
+      return _matches;
+    },
+    addListener(cb) {
+      listeners = [...listeners, cb];
+    },
+    removeListener(cb) {
+      listeners = listeners.filter(l => l !== cb);
+    }
+  };
+});
+
+export function setMatches(matches) {
+  _matches = matches;
+  listeners.forEach(l => l());
+}


### PR DESCRIPTION
Fixes cleanup issue where we don't cancel listening to MediaQueryList when a component is unmounted.
Mock matchMedia better, including addListener and removeListener.
Adds appropriate tests.