### PR TITLE
Use useLayoutEffect instead of refs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,40 +1,25 @@
 import React from "react";
 
 export function useMediaQuery(query) {
-  const lastQuery = React.useRef();
-  const cancel = React.useRef();
   const [matches, setMatches] = React.useState();
 
-  if (lastQuery.current !== query) {
-    if (cancel.current) {
-      cancel.current();
-      cancel.current = null;
-    }
-
-    if (query) {
-      const mq = window.matchMedia(query);
-      const cb = () => {
+  React.useLayoutEffect(
+    () => {
+      if (query) {
+        const mq = window.matchMedia(query);
+        const cb = () => {
+          setMatches(mq.matches);
+        };
+        mq.addListener(cb);
         setMatches(mq.matches);
-      };
-      mq.addListener(cb);
 
-      cancel.current = () => {
-        mq.removeListener(cb);
-      };
-
-      if (
-        lastQuery.current === undefined ||
-        lastQuery.current === null ||
-        lastQuery.current === ""
-      ) {
-        setMatches(mq.matches);
+        return () => {
+          mq.removeListener(cb);
+        };
       }
-    }
-
-    lastQuery.current = query;
-  }
-
-  React.useEffect(() => cancel.current, [cancel.current]);
+    },
+    [query]
+  );
 
   return matches;
 }


### PR DESCRIPTION
Initially it was chosen to use refs instead of useEffect because useEffect occurs after the first layout and paint, whereas our approach with refs allowed us to control the first layout and paint. Using useLayoutEffect also gives us the benefit of controlling the first render while also keeping the code much cleaner.